### PR TITLE
Fixes the baseurl so pages will include CSS rather than 404

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-baseurl: /tech-and-data-standards
+baseurl: /open-standards
 
 theme: jekyll-theme-minimal
 


### PR DESCRIPTION
Fixes the baseurl for the generated page

The page at https://alphagov.github.io/open-standards/ is broken because
it can't load the CSS from tech-and-data-standards (and github doesn't redirect
from renamed repos in pages), so this PR should fix that be allowing it to be 
loaded from open-standards/css/main.css